### PR TITLE
fix(ci-cd): ensure build runs prbuild before build in firebase-hosting-merge.yml

### DIFF
--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -74,7 +74,7 @@ jobs:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
           JINAAI_API_KEY: ${{ secrets.JINAAI_API_KEY }}
-        run: npm run build
+        run: npm run prbuild && npm run build
       - name: Install Functions Dependencies
         working-directory: ./functions
         run: npm ci


### PR DESCRIPTION
## Summary
This commit ensures that the `prbuild` script is executed before the `build` script in the `firebase-hosting-merge.yml` workflow. This is necessary to generate the production environment file before the Angular application is built for deployment.

