### PR TITLE
refactor: Firebase Functions deployment and fix production check

### DIFF
--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -113,11 +113,12 @@ jobs:
           entryPoint: "."
           expires: "never"
       - name: Deploy Firebase Functions
-        run: |
-          npm install -g firebase-tools
-          run: firebase deploy --only functions --project libnet-d76db
+        uses: w9jds/firebase-action@v2.2.0
+        with:
+          args: deploy --only functions --project libnet-d76db
         env:
           PRODUCTION: true
+          FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}

--- a/server.ts
+++ b/server.ts
@@ -130,7 +130,7 @@ function run(): void {
 
 let reqHandler: express.Application
 
-if (process.env['PRODUCTION'] === 'true') {
+if (process.env['PRODUCTION'] === 'false') {
   run()
 } else {
   reqHandler = createNodeRequestHandler(serveapp())


### PR DESCRIPTION
Update the CI/CD workflow to use the 'w9jds/firebase-action' for deploying Firebase Functions. This streamlines the deployment process and improves security by utilizing a dedicated action and the FIREBASE_TOKEN.

Correct the environment check in 'server.ts' to properly differentiate between production and development modes. The 'run()' function now executes when 'PRODUCTION' is 'false', ensuring the application starts correctly in development environments.